### PR TITLE
feat: define an exception to use when introspect or userinfo fail

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>io.gravitee.resource</groupId>
     <artifactId>gravitee-resource-oauth2-provider-api</artifactId>
-    <version>1.3.0</version>
+    <version>1.4.0-apim-3382-handle-technical-exception-SNAPSHOT</version>
 
     <name>Gravitee.io APIM - Resource - OAuth2 Provider API</name>
 

--- a/src/main/java/io/gravitee/resource/oauth2/api/OAuth2ResourceException.java
+++ b/src/main/java/io/gravitee/resource/oauth2/api/OAuth2ResourceException.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.resource.oauth2.api;
+
+public class OAuth2ResourceException extends Exception {
+
+    public OAuth2ResourceException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-3382

**Description**

Define an exception to use when introspect or userinfo fail
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.4.0-apim-3382-handle-technical-exception-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/resource/gravitee-resource-oauth2-provider-api/1.4.0-apim-3382-handle-technical-exception-SNAPSHOT/gravitee-resource-oauth2-provider-api-1.4.0-apim-3382-handle-technical-exception-SNAPSHOT.zip)
  <!-- Version placeholder end -->
