### PR TITLE
feat: Introduce support for OAuth 2.0 Token Exchange (RFC 8693) defin…

### DIFF
--- a/src/main/java/io/gravitee/resource/oauth2/api/OAuth2Resource.java
+++ b/src/main/java/io/gravitee/resource/oauth2/api/OAuth2Resource.java
@@ -19,6 +19,8 @@ import io.gravitee.gateway.api.handler.Handler;
 import io.gravitee.resource.api.AbstractConfigurableResource;
 import io.gravitee.resource.api.ResourceConfiguration;
 import io.gravitee.resource.oauth2.api.openid.UserInfoResponse;
+import io.gravitee.resource.oauth2.api.tokenexchange.TokenExchangeRequest;
+import io.gravitee.resource.oauth2.api.tokenexchange.TokenExchangeResponse;
 import java.util.List;
 
 /**
@@ -33,6 +35,16 @@ public abstract class OAuth2Resource<C extends ResourceConfiguration> extends Ab
     public abstract void introspect(String accessToken, Handler<OAuth2Response> responseHandler);
 
     public abstract void userInfo(String accessToken, Handler<UserInfoResponse> responseHandler);
+
+    /**
+     * Performs an OAuth 2.0 Token Exchange as defined by RFC 8693.
+     * Override this method in a resource implementation to support token exchange.
+     */
+    public void tokenExchange(TokenExchangeRequest tokenExchangeRequest, Handler<TokenExchangeResponse> responseHandler) {
+        responseHandler.handle(
+            new TokenExchangeResponse(new UnsupportedOperationException("Token exchange is not supported by this OAuth2 resource"))
+        );
+    }
 
     public String getScopeSeparator() {
         return DEFAULT_SCOPE_SEPARATOR;

--- a/src/main/java/io/gravitee/resource/oauth2/api/tokenexchange/TokenExchangeRequest.java
+++ b/src/main/java/io/gravitee/resource/oauth2/api/tokenexchange/TokenExchangeRequest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.resource.oauth2.api.tokenexchange;
+
+/**
+ * Represents an OAuth 2.0 Token Exchange request as defined by RFC 8693.
+ */
+public class TokenExchangeRequest {
+
+    public static final String TOKEN_TYPE_ACCESS_TOKEN = "urn:ietf:params:oauth:token-type:access_token";
+    public static final String TOKEN_TYPE_REFRESH_TOKEN = "urn:ietf:params:oauth:token-type:refresh_token";
+    public static final String TOKEN_TYPE_ID_TOKEN = "urn:ietf:params:oauth:token-type:id_token";
+    public static final String TOKEN_TYPE_SAML1 = "urn:ietf:params:oauth:token-type:saml1";
+    public static final String TOKEN_TYPE_SAML2 = "urn:ietf:params:oauth:token-type:saml2";
+    public static final String TOKEN_TYPE_JWT = "urn:ietf:params:oauth:token-type:jwt";
+
+    private final String subjectToken;
+    private final String subjectTokenType;
+    private final String resource;
+    private final String audience;
+    private final String scope;
+    private final String requestedTokenType;
+    private final String actorToken;
+    private final String actorTokenType;
+
+    private TokenExchangeRequest(Builder builder) {
+        this.subjectToken = builder.subjectToken;
+        this.subjectTokenType = builder.subjectTokenType;
+        this.resource = builder.resource;
+        this.audience = builder.audience;
+        this.scope = builder.scope;
+        this.requestedTokenType = builder.requestedTokenType;
+        this.actorToken = builder.actorToken;
+        this.actorTokenType = builder.actorTokenType;
+    }
+
+    public static Builder builder(String subjectToken, String subjectTokenType) {
+        return new Builder(subjectToken, subjectTokenType);
+    }
+
+    public String getSubjectToken() {
+        return subjectToken;
+    }
+
+    public String getSubjectTokenType() {
+        return subjectTokenType;
+    }
+
+    public String getResource() {
+        return resource;
+    }
+
+    public String getAudience() {
+        return audience;
+    }
+
+    public String getScope() {
+        return scope;
+    }
+
+    public String getRequestedTokenType() {
+        return requestedTokenType;
+    }
+
+    public String getActorToken() {
+        return actorToken;
+    }
+
+    public String getActorTokenType() {
+        return actorTokenType;
+    }
+
+    public static class Builder {
+
+        private final String subjectToken;
+        private final String subjectTokenType;
+        private String resource;
+        private String audience;
+        private String scope;
+        private String requestedTokenType;
+        private String actorToken;
+        private String actorTokenType;
+
+        private Builder(String subjectToken, String subjectTokenType) {
+            this.subjectToken = subjectToken;
+            this.subjectTokenType = subjectTokenType;
+        }
+
+        public Builder resource(String resource) {
+            this.resource = resource;
+            return this;
+        }
+
+        public Builder audience(String audience) {
+            this.audience = audience;
+            return this;
+        }
+
+        public Builder scope(String scope) {
+            this.scope = scope;
+            return this;
+        }
+
+        public Builder requestedTokenType(String requestedTokenType) {
+            this.requestedTokenType = requestedTokenType;
+            return this;
+        }
+
+        public Builder actorToken(String actorToken, String actorTokenType) {
+            this.actorToken = actorToken;
+            this.actorTokenType = actorTokenType;
+            return this;
+        }
+
+        public TokenExchangeRequest build() {
+            return new TokenExchangeRequest(this);
+        }
+    }
+}

--- a/src/main/java/io/gravitee/resource/oauth2/api/tokenexchange/TokenExchangeResponse.java
+++ b/src/main/java/io/gravitee/resource/oauth2/api/tokenexchange/TokenExchangeResponse.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.resource.oauth2.api.tokenexchange;
+
+/**
+ * Represents an OAuth 2.0 Token Exchange response as defined by RFC 8693.
+ */
+public class TokenExchangeResponse {
+
+    private final boolean success;
+    private final String accessToken;
+    private final String issuedTokenType;
+    private final String tokenType;
+    private final Long expiresIn;
+    private final String scope;
+    private final String refreshToken;
+    private final Throwable throwable;
+
+    private TokenExchangeResponse(Builder builder) {
+        this.success = true;
+        this.accessToken = builder.accessToken;
+        this.issuedTokenType = builder.issuedTokenType;
+        this.tokenType = builder.tokenType;
+        this.expiresIn = builder.expiresIn;
+        this.scope = builder.scope;
+        this.refreshToken = builder.refreshToken;
+        this.throwable = null;
+    }
+
+    public TokenExchangeResponse(Throwable throwable) {
+        this.success = false;
+        this.throwable = throwable;
+        this.accessToken = null;
+        this.issuedTokenType = null;
+        this.tokenType = null;
+        this.expiresIn = null;
+        this.scope = null;
+        this.refreshToken = null;
+    }
+
+    public static Builder builder(String accessToken, String issuedTokenType, String tokenType) {
+        return new Builder(accessToken, issuedTokenType, tokenType);
+    }
+
+    public boolean isSuccess() {
+        return success;
+    }
+
+    public String getAccessToken() {
+        return accessToken;
+    }
+
+    public String getIssuedTokenType() {
+        return issuedTokenType;
+    }
+
+    public String getTokenType() {
+        return tokenType;
+    }
+
+    public Long getExpiresIn() {
+        return expiresIn;
+    }
+
+    public String getScope() {
+        return scope;
+    }
+
+    public String getRefreshToken() {
+        return refreshToken;
+    }
+
+    public Throwable getThrowable() {
+        return throwable;
+    }
+
+    public static class Builder {
+
+        private final String accessToken;
+        private final String issuedTokenType;
+        private final String tokenType;
+        private Long expiresIn;
+        private String scope;
+        private String refreshToken;
+
+        private Builder(String accessToken, String issuedTokenType, String tokenType) {
+            this.accessToken = accessToken;
+            this.issuedTokenType = issuedTokenType;
+            this.tokenType = tokenType;
+        }
+
+        public Builder expiresIn(Long expiresIn) {
+            this.expiresIn = expiresIn;
+            return this;
+        }
+
+        public Builder scope(String scope) {
+            this.scope = scope;
+            return this;
+        }
+
+        public Builder refreshToken(String refreshToken) {
+            this.refreshToken = refreshToken;
+            return this;
+        }
+
+        public TokenExchangeResponse build() {
+            return new TokenExchangeResponse(this);
+        }
+    }
+}


### PR DESCRIPTION
**Description**

Draft changes introducing support for OAuth 2.0 Token Exchange (RFC 8693) definitions
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.6.0-token-exchange-support-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/resource/gravitee-resource-oauth2-provider-api/1.6.0-token-exchange-support-SNAPSHOT/gravitee-resource-oauth2-provider-api-1.6.0-token-exchange-support-SNAPSHOT.zip)
  <!-- Version placeholder end -->
